### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,14 +7,8 @@ Runner
 
 > Using Composer and Packagist
 
-in composer.json file add:
-
-```json
-{
-    "require": {
-        "g4/runner": "*"
-    }
-}
+```sh
+composer require g4/runner
 ```
 
 ## Usage


### PR DESCRIPTION
Updated installation instructions via composer to use the `composer require` command without specifying a version.
This is the new recommended way of providing this information and it leads to composer picking the proper version constraint (i.e ~1.2), updating the `composer.json` and running install, all in one command.
