### PR TITLE
Added __dbprofiler=2 to order profiler items by time

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "g4/clean-core"  : "*",
         "g4/http"        : "*",
         "g4/di"          : "*",
-        "g4/profiler"    : ">=1.10.0",
+        "g4/profiler"    : ">=1.11.0",
         "g4/factory"     : "1.*",
         "twig/twig"      : "1.*",
         "twig/extensions": "^1.2",

--- a/src/Presenter/Formatter/FormatterAbstract.php
+++ b/src/Presenter/Formatter/FormatterAbstract.php
@@ -47,7 +47,12 @@ abstract class FormatterAbstract implements FormatterInterface
     public function getProfilerData()
     {
         return $this->isProfilerEnabled()
-            ? ['profiler' =>  $this->getDataTransfer()->getProfiler()->getProfilerOutput($this->getDataTransfer()->getResponse()->getHttpResponseCode())]
+            ? [
+                'profiler' =>  $this->getDataTransfer()->getProfiler()->getProfilerOutput(
+                    $this->getDataTransfer()->getResponse()->getHttpResponseCode(),
+                    $this->getDbProfilerRequestParam()
+                )
+            ]
             : [];
     }
 
@@ -59,7 +64,16 @@ abstract class FormatterAbstract implements FormatterInterface
 
     private function isProfilerEnabled()
     {
+        return $this->getDbProfilerRequestParam() !== null;
+    }
+
+    /**
+     * @return int|null
+     */
+    protected function getDbProfilerRequestParam()
+    {
         return $this->getDataTransfer()->getHttpRequest()->has(Override::DB_PROFILER)
-            && $this->getDataTransfer()->getHttpRequest()->get(Override::DB_PROFILER) == 1;
+            ? (int) $this->getDataTransfer()->getHttpRequest()->get(Override::DB_PROFILER)
+            : null;
     }
 }


### PR DESCRIPTION
This commit enhances the g4/profiler package by introducing a new way to order profiler items by time using the __dbprofiler=2 parameter. It improves the profiling functionality by providing an additional, time-oriented view of the profiler's data which is crucial during performance optimization. This was facilitated by splitting the logic for retrieving DB Profiler request parameters and reformatting the output of the getFormatted() function based on the request parameter value. Also, g4/profiler has been updated to version >=1.11.0.